### PR TITLE
Issue 2635 Migrate Dockerhub to ACR

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM jaybuckeye2006/zephyr-env:latest
+FROM waresimpleastusdevacr0.azurecr.io/zephyr-env:v3.6.0


### PR DESCRIPTION
Changed image in Dockerfile to point to ACR instead of Dockerhub version